### PR TITLE
Add homerow mods and layer-tap behaviors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a ZMK (Zephyr Mechanical Keyboard) firmware configuration for a Corne V3 split keyboard using Nice Nano v2 controllers. The configuration includes:
+- Custom RGB LED configuration (27 LEDs per side)
+- OLED display support with WPM tracking
+- Split keyboard architecture
+- Bluetooth connectivity with output toggling
+
+## Building the Firmware
+
+This repository uses GitHub Actions for automated builds. Push to the repository triggers builds for both left and right keyboard halves.
+
+### Build Configuration
+
+The `build.yaml` file defines the build matrix:
+- Board: nice_nano_v2
+- Shields: corne_v3_left, corne_v3_right
+
+Firmware files are generated as GitHub Actions artifacts.
+
+## Repository Structure
+
+```
+config/
+├── boards/shields/corne_v3/     # Custom Corne V3 shield definition
+│   ├── corne_v3.dtsi            # Base device tree (matrix, OLED, kscan)
+│   ├── corne_v3_left.overlay    # Left half GPIO configuration
+│   ├── corne_v3_right.overlay   # Right half GPIO configuration
+│   ├── boards/
+│   │   └── nice_nano_v2.overlay # RGB LED strip configuration (27 LEDs)
+│   ├── Kconfig.defconfig        # Default config (I2C, display, split)
+│   └── corne_v3.zmk.yml         # Shield metadata
+├── corne_v3.keymap              # Main keymap definition
+├── corne_v3.conf                # Keyboard configuration
+└── west.yml                     # West manifest (ZMK dependency)
+zephyr/module.yml                # Zephyr module definition (sets board_root)
+```
+
+## Keymap Architecture
+
+The keymap (`config/corne_v3.keymap`) uses a 6-layer structure:
+
+1. **ALPHA** (layer 0): Default QWERTY layout
+2. **NUM** (layer 1): Numbers and navigation arrows
+3. **SYMBOL** (layer 2): Symbols and punctuation
+4. **FUNC** (layer 3): Function keys (F1-F10)
+5. **BT** (layer 4): Bluetooth management and output selection
+6. **RGB** (layer 5): RGB underglow controls
+
+Layer access uses momentary layer switches (`&mo N`). The BT and RGB layers are accessed via layer 3 and layer 4 respectively.
+
+## Hardware Configuration Details
+
+### RGB Underglow
+
+Configured in `config/boards/shields/corne_v3/boards/nice_nano_v2.overlay`:
+- 27 LEDs per side (chain-length = 27)
+- SPI-based WS2812 control on pin P0.06
+- Color mapping: GRB
+- Controlled via layer 5 (RGB layer)
+
+### Split Configuration
+
+- Left side is the central (primary) controller
+- Set in `Kconfig.defconfig` with `ZMK_SPLIT_ROLE_CENTRAL=y` for left shield
+- Communication via Bluetooth
+
+### Display
+
+- OLED: SSD1306 128x32
+- I2C address: 0x3c
+- Features: WPM tracking enabled
+
+### Power Settings
+
+- External power control enabled (`ZMK_EXT_POWER=y`)
+- Sleep disabled (`ZMK_SLEEP=n`)
+- Idle timeout: 300 seconds
+- RGB underglow disabled on start, no auto-off on USB
+
+## Making Changes
+
+### Modifying the Keymap
+
+Edit `config/corne_v3.keymap`:
+- Each layer has a `bindings` matrix with 3 rows of 12 keys plus 3 thumb keys per side
+- Use ZMK behavior bindings like `&kp`, `&mo`, `&bt`, `&rgb_ug`, `&out`
+- Bindings are defined in left-to-right, top-to-bottom order
+
+### Adjusting RGB LED Count
+
+If you have a different number of LEDs:
+1. Edit `config/boards/shields/corne_v3/boards/nice_nano_v2.overlay`
+2. Change `chain-length = <27>;` to your LED count
+
+### Configuration Options
+
+Edit `config/corne_v3.conf` for settings like:
+- Display enable/disable
+- RGB underglow behavior
+- Power management
+- Keyboard name
+
+## Testing Changes
+
+1. Push changes to trigger GitHub Actions build
+2. Download firmware artifacts from Actions tab
+3. Flash `.uf2` files to each keyboard half by copying to the mounted drive
+4. Reset keyboard to bootloader mode (double-tap reset button)

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -15,15 +15,28 @@
 #include <dt-bindings/zmk/rgb.h>
 #include <dt-bindings/zmk/outputs.h>
 / {
+    behaviors {
+        hm: homerow_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HOMEROW_MODS";
+            #binding-cells = <2>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <150>;
+            flavor = "balanced";
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 
         default_layer {
             bindings = <
-  &kp TAB  &kp Q  &kp W     &kp E  &kp R      &kp T      &kp Y  &kp U      &kp I    &kp O     &kp P   &kp BSPC
-&kp LSHFT  &kp A  &kp S     &kp D  &kp F      &kp G      &kp H  &kp J      &kp K    &kp L  &kp SEMI    &kp SQT
-&kp LCTRL  &kp Z  &kp X     &kp C  &kp V      &kp B      &kp N  &kp M  &kp COMMA  &kp DOT  &kp FSLH  &kp RSHFT
-                         &kp LGUI  &mo 1  &kp SPACE    &kp RET  &mo 2   &kp RALT
+     &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O      &kp P   &kp BSPC
+  &kp ESCAPE  &hm LGUI A  &hm LALT S  &hm LCTRL D  &hm LSHFT F      &kp G      &kp H  &hm RSHFT J  &hm RCTRL K  &hm RALT L  &hm RGUI SEMI    &kp SQT
+&kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT   &kp FSLH  &kp RSHFT
+                                     &kp LGUI        &mo 1  &kp SPACE    &kp RET        &mo 2     &kp RALT
             >;
 
             display-name = "ALPHA";

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -26,6 +26,26 @@
             flavor = "balanced";
             bindings = <&kp>, <&kp>;
         };
+
+        lt_spc: layer_tap_space {
+            compatible = "zmk,behavior-hold-tap";
+            label = "LAYER_TAP_SPACE";
+            #binding-cells = <2>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <200>;
+            flavor = "balanced";
+            bindings = <&mo>, <&kp>;
+        };
+
+        lt_ret: layer_tap_return {
+            compatible = "zmk,behavior-hold-tap";
+            label = "LAYER_TAP_RETURN";
+            #binding-cells = <2>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <200>;
+            flavor = "balanced";
+            bindings = <&mo>, <&kp>;
+        };
     };
 
     keymap {
@@ -36,7 +56,7 @@
      &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O      &kp P   &kp BSPC
   &kp ESCAPE  &hm LGUI A  &hm LALT S  &hm LCTRL D  &hm LSHFT F      &kp G      &kp H  &hm RSHFT J  &hm RCTRL K  &hm RALT L  &hm RGUI SEMI    &kp SQT
 &kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT   &kp FSLH  &kp RSHFT
-                                     &kp LGUI        &mo 1  &kp SPACE    &kp RET        &mo 2     &kp RALT
+                                     &kp LGUI   &kp LSHFT  &lt_spc 1 SPACE    &lt_ret 2 RET   &kp RSHFT     &kp RALT
             >;
 
             display-name = "ALPHA";
@@ -47,7 +67,7 @@
 &kp ESC  &kp N1        &kp N2    &kp N3  &kp N4     &kp N5            &kp N6    &kp N7          &kp N8           &kp N9  &kp N0  &kp BACKSPACE
  &trans  &kp N4        &kp N5    &kp N6  &kp N0      &none          &kp LEFT  &kp DOWN          &kp UP        &kp RIGHT  &trans        &kp DEL
  &trans  &kp N7  &kp NUMBER_8    &kp N9  &kp N0      &none    &kp UNDERSCORE  &kp PLUS  &kp LEFT_BRACE  &kp RIGHT_BRACE  &trans         &trans
-                               &kp LGUI  &trans  &kp SPACE           &kp RET  &kp RCMD        &kp RALT
+                               &kp LGUI  &trans     &trans            &trans  &trans        &kp RALT
             >;
 
             display-name = "NUM";
@@ -58,7 +78,7 @@
 &kp ESC  &kp EXCL  &kp AT   &kp HASH  &kp DLLR  &kp PRCNT    &kp CARET   &kp AMPS   &kp KP_MULTIPLY  &kp LPAR &kp RPAR  &kp BACKSPACE
  &trans    &trans  &kp LPAR &kp RPAR  &kp LBKT  &kp RBKT     &kp MINUS   &kp EQUAL  &trans           &trans   &kp BSLH  &kp GRAVE
  &trans    &trans  &trans   &trans    &kp LBRC  &kp RBRC     &kp UNDER   &kp PLUS   &trans           &trans   &kp PIPE  &kp TILDE
-                           &kp LGUI     &mo 3  &kp SPACE      &kp RET     &trans           &trans
+                           &kp LGUI     &mo 3     &trans         &trans     &trans           &trans
             >;
 
             display-name = "SYMBOL";


### PR DESCRIPTION
## Summary

This PR enhances the Corne V3 keymap with ergonomic improvements and adds repository documentation:

- **Homerow mods**: Home row keys (ASDF/JKL;) now act as modifiers when held (GUI/Alt/Ctrl/Shift)
- **Layer-tap behaviors**: Space and Enter keys activate layers when held
- **CLAUDE.md**: Comprehensive repository documentation for future development

## Changes

### Homerow Mods
- Left hand: A (GUI), S (Alt), D (Ctrl), F (Shift)
- Right hand: J (Shift), K (Ctrl), L (Alt), ; (GUI)
- Configured with balanced timing (200ms tapping term, 150ms prior-idle to prevent accidental activation)

### Layer-Tap Behaviors
- **Space**: Tap for space character, hold for NUM layer (L1)
- **Enter**: Tap for enter, hold for SYMBOL layer (L2)
- Frees up middle thumb positions for dedicated shift keys
- Maintains alternating layer navigation pattern through all 6 layers

### Documentation
- Added CLAUDE.md with project structure, build instructions, and hardware details
- Includes keymap architecture and configuration guidance

## Test Plan

- [ ] Flash firmware to both keyboard halves
- [ ] Test homerow mods with various modifier combinations (Ctrl+C, Cmd+T, Shift+V)
- [ ] Verify layer-tap behaviors work on all layers
- [ ] Test layer navigation flow (L0→L1→L2→L3→L4→L5)
- [ ] Confirm no accidental modifier activation during normal typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)