### PR TITLE
feat: add hyperkey macro to right shift key

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -48,6 +48,17 @@
         };
     };
 
+    macros {
+        hyper: hyper {
+            compatible = "zmk,behavior-macro";
+            label = "HYPER";
+            #binding-cells = <0>;
+            bindings = <&macro_press &kp LSHFT &kp LCTRL &kp LALT &kp LGUI>,
+                       <&macro_pause_for_release>,
+                       <&macro_release &kp LSHFT &kp LCTRL &kp LALT &kp LGUI>;
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 
@@ -55,7 +66,7 @@
             bindings = <
      &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O      &kp P   &kp BSPC
   &kp ESCAPE  &hm LGUI A  &hm LALT S  &hm LCTRL D  &hm LSHFT F      &kp G      &kp H  &hm RSHFT J  &hm RCTRL K  &hm RALT L  &hm RGUI SEMI    &kp SQT
-&kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT   &kp FSLH  &kp RSHFT
+&kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT   &kp FSLH     &hyper
                                      &kp LGUI   &kp LSHFT  &lt_spc 1 SPACE    &lt_ret 2 RET   &kp RSHFT     &kp RALT
             >;
 


### PR DESCRIPTION
## Summary

- Added a hyperkey macro that combines Shift+Control+Alt+Command
- Replaced the far-right shift key on the bottom row with the hyperkey
- Enables creation of unique global shortcuts that won't conflict with existing apps

## Implementation

The hyperkey is implemented as a ZMK macro that:
- Presses all four modifiers (Shift, Control, Alt, GUI) simultaneously
- Holds them while the key is held
- Releases all modifiers when the key is released

## Usage

After flashing the firmware, the right shift key (bottom-right corner) will act as a hyperkey. Use it to create shortcuts like:
- Hyper+A, Hyper+B, etc. in your OS or applications
- Perfect for window management, app launching, or custom automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)