### PR TITLE
fix: change space key to tap-preferred flavor

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -33,7 +33,7 @@
             #binding-cells = <2>;
             tapping-term-ms = <150>;
             quick-tap-ms = <150>;
-            flavor = "balanced";
+            flavor = "tap-preferred";
             bindings = <&mo>, <&kp>;
         };
 


### PR DESCRIPTION
## Summary
- Changed space key behavior from "balanced" to "tap-preferred" flavor to prevent missed spaces during fast typing

## Background
The space key uses a layer-tap behavior (`lt_spc`) that activates layer 1 on hold and space on tap. With the "balanced" flavor, the keyboard was sometimes missing space taps during fast typing because it was trying to determine whether the press was a tap or hold.

## Changes
- Updated `lt_spc` behavior in `config/corne_v3.keymap` to use `flavor = "tap-preferred"`
- This prioritizes registering space taps over layer activation
- Layer access on hold is still available, but the behavior is less aggressive during fast typing

## Test plan
- [ ] Flash updated firmware to keyboard
- [ ] Test fast typing to verify spaces register consistently
- [ ] Verify layer 1 still activates when holding space
- [ ] Confirm no regression in other key behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)