### PR TITLE
Improve space and homerow mod timing

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -20,9 +20,9 @@
             compatible = "zmk,behavior-hold-tap";
             label = "HOMEROW_MODS";
             #binding-cells = <2>;
-            tapping-term-ms = <150>;
-            quick-tap-ms = <150>;
-            require-prior-idle-ms = <150>;
+            tapping-term-ms = <175>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <175>;
             flavor = "balanced";
             bindings = <&kp>, <&kp>;
         };
@@ -31,8 +31,8 @@
             compatible = "zmk,behavior-hold-tap";
             label = "LAYER_TAP_SPACE";
             #binding-cells = <2>;
-            tapping-term-ms = <150>;
-            quick-tap-ms = <150>;
+            tapping-term-ms = <250>;
+            quick-tap-ms = <250>;
             flavor = "tap-preferred";
             bindings = <&mo>, <&kp>;
         };

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -33,7 +33,7 @@
             #binding-cells = <2>;
             tapping-term-ms = <150>;
             quick-tap-ms = <150>;
-            flavor = "balanced";
+            flavor = "tap-preferred";
             bindings = <&mo>, <&kp>;
         };
 


### PR DESCRIPTION
## Summary
- Changed space key to tap-preferred flavor with 250ms timing to prevent missed spaces
- Increased homerow mod timings to 175ms for more reliable modifier activation

## Background
The space key was missing taps during fast typing with the balanced flavor and 150ms timing. Since space is nearly always used as a tap rather than a layer hold, these changes prioritize reliable space registration.

## Changes

### Space Key (`lt_spc`)
- Changed flavor from `balanced` to `tap-preferred`
- Increased `tapping-term-ms` from 150ms to 250ms
- Increased `quick-tap-ms` from 150ms to 250ms

### Homerow Mods (`hm`)
- Increased `tapping-term-ms` from 150ms to 175ms
- Increased `quick-tap-ms` from 150ms to 175ms
- Increased `require-prior-idle-ms` from 150ms to 175ms

## Test plan
- [ ] Flash updated firmware to keyboard
- [ ] Test fast typing to verify spaces register consistently
- [ ] Verify homerow mods still activate reliably when held
- [ ] Verify layer 1 still activates when holding space for 250ms
- [ ] Confirm no regression in typing feel

🤖 Generated with [Claude Code](https://claude.com/claude-code)