### PR TITLE
feat: add caps word combo for homerow shift keys

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -69,6 +69,15 @@
         };
     };
 
+    combos {
+        compatible = "zmk,combos";
+        combo_caps_word {
+            timeout-ms = <50>;
+            key-positions = <16 19>;
+            bindings = <&caps_word>;
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 


### PR DESCRIPTION
## Summary

- Add combo that triggers Caps Word when both homerow shift keys (F and J) are pressed simultaneously
- Provides ergonomic alternative to traditional caps lock
- Automatically capitalizes words and turns off after word-breaking characters (space, punctuation, etc.)

## Implementation Details

- Combo timeout: 50ms
- Key positions: 16 (F - left shift) and 19 (J - right shift)
- Uses ZMK's built-in `&caps_word` behavior

## Test Plan

- [ ] Flash firmware to keyboard
- [ ] Test pressing F+J simultaneously activates Caps Word
- [ ] Verify typing capitalizes letters automatically
- [ ] Confirm Caps Word turns off after pressing space or punctuation
- [ ] Ensure regular F and J homerow mod functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)