### PR TITLE
feat: add caps lock toggle on escape key hold

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -47,9 +47,9 @@
             bindings = <&mo>, <&kp>;
         };
 
-        esc_noop: escape_noop {
+        esc_hold: escape_hold {
             compatible = "zmk,behavior-hold-tap";
-            label = "ESCAPE_NOOP";
+            label = "ESCAPE_HOLD";
             #binding-cells = <2>;
             tapping-term-ms = <200>;
             quick-tap-ms = <200>;
@@ -84,7 +84,7 @@
         default_layer {
             bindings = <
           &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O       &kp P   &kp BSPC
-  &esc_noop N0 ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &kp G      &kp H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
+  &esc_hold CAPS ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &kp G      &kp H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
          &kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &hyper
                                               &kp LGUI   &kp LSHFT  &lt_spc 1 SPACE    &lt_ret 2 RET   &kp RSHFT     &kp RALT
             >;


### PR DESCRIPTION
## Summary

- Configures escape key to toggle caps lock when held for >200ms
- Renames behavior from `esc_noop` to `esc_hold` for clarity
- Maintains normal escape functionality on tap

## Test plan

- [ ] Flash firmware to both keyboard halves
- [ ] Verify tapping escape sends ESC normally
- [ ] Verify holding escape (>200ms) toggles caps lock on/off
- [ ] Confirm no interference with other key behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)