### PR TITLE
Keyboard refinements: layer access, timing, and caps lock improvements

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -84,9 +84,9 @@
         default_layer {
             bindings = <
           &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O       &kp P   &kp BSPC
-  &esc_hold CAPS ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &kp G      &kp H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
+  &esc_hold CAPS ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &kp G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
          &kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &hyper
-                                              &kp LGUI   &kp LSHFT  &lt_spc 1 SPACE    &lt_ret 2 RET   &kp RSHFT     &kp RALT
+                                              &kp LGUI   &kp LSHFT  &lt_spc 2 SPACE    &kp RET   &kp RSHFT     &kp RALT
             >;
 
             display-name = "ALPHA";

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -95,8 +95,8 @@
         default_layer {
             bindings = <
           &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O       &kp P   &kp BSPC
-  &esc_hold CAPS ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm_hold_pref LSHFT F      &kp G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
-         &kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &hyper
+  &kp ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm_hold_pref LSHFT F      &kp G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
+         &kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &kp CAPS
                                               &kp LGUI   &kp LSHFT  &lt_spc 2 SPACE    &kp RET   &kp RSHFT     &kp RALT
             >;
 

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -27,17 +27,6 @@
             bindings = <&kp>, <&kp>;
         };
 
-        hm_hold_pref: homerow_mods_hold_preferred {
-            compatible = "zmk,behavior-hold-tap";
-            label = "HOMEROW_MODS_HOLD_PREFERRED";
-            #binding-cells = <2>;
-            tapping-term-ms = <150>;
-            quick-tap-ms = <125>;
-            require-prior-idle-ms = <100>;
-            flavor = "hold-preferred";
-            bindings = <&kp>, <&kp>;
-        };
-
         lt_spc: layer_tap_space {
             compatible = "zmk,behavior-hold-tap";
             label = "LAYER_TAP_SPACE";
@@ -95,7 +84,7 @@
         default_layer {
             bindings = <
           &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O       &kp P   &kp BSPC
-  &kp ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm_hold_pref LSHFT F      &kp G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
+  &kp ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &kp G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
          &kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &kp CAPS
                                               &kp LGUI   &kp LSHFT  &lt_spc 2 SPACE    &kp RET   &kp RSHFT     &kp RALT
             >;

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -27,6 +27,17 @@
             bindings = <&kp>, <&kp>;
         };
 
+        hm_hold_pref: homerow_mods_hold_preferred {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HOMEROW_MODS_HOLD_PREFERRED";
+            #binding-cells = <2>;
+            tapping-term-ms = <175>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <175>;
+            flavor = "hold-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+
         lt_spc: layer_tap_space {
             compatible = "zmk,behavior-hold-tap";
             label = "LAYER_TAP_SPACE";
@@ -84,7 +95,7 @@
         default_layer {
             bindings = <
           &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O       &kp P   &kp BSPC
-  &esc_hold CAPS ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &kp G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
+  &esc_hold CAPS ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm_hold_pref LSHFT F      &kp G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
          &kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &hyper
                                               &kp LGUI   &kp LSHFT  &lt_spc 2 SPACE    &kp RET   &kp RSHFT     &kp RALT
             >;

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -105,7 +105,7 @@
 
         layer_raise {
             bindings = <
-&kp ESC  &kp EXCL  &kp AT   &kp HASH  &kp DLLR  &kp PRCNT    &kp CARET   &kp AMPS   &kp KP_MULTIPLY  &kp LPAR &kp RPAR  &kp BACKSPACE
+&kp ESC  &kp EXCL  &kp AT   &kp HASH  &kp DLLR  &kp PRCNT    &kp CARET   &kp AMPS   &kp KP_MULTIPLY  &kp LPAR &kp RPAR  &kp DEL
  &trans    &trans  &kp LPAR &kp RPAR  &kp LBKT  &kp RBKT     &kp MINUS   &kp EQUAL  &trans           &trans   &kp BSLH  &kp GRAVE
  &trans    &trans  &trans   &trans    &kp LBRC  &kp RBRC     &kp UNDER   &kp PLUS   &trans           &trans   &kp PIPE  &kp TILDE
                            &kp LGUI     &mo 3     &trans         &trans     &trans           &trans

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -20,9 +20,9 @@
             compatible = "zmk,behavior-hold-tap";
             label = "HOMEROW_MODS";
             #binding-cells = <2>;
-            tapping-term-ms = <175>;
-            quick-tap-ms = <175>;
-            require-prior-idle-ms = <175>;
+            tapping-term-ms = <150>;
+            quick-tap-ms = <125>;
+            require-prior-idle-ms = <100>;
             flavor = "balanced";
             bindings = <&kp>, <&kp>;
         };
@@ -31,9 +31,9 @@
             compatible = "zmk,behavior-hold-tap";
             label = "HOMEROW_MODS_HOLD_PREFERRED";
             #binding-cells = <2>;
-            tapping-term-ms = <175>;
-            quick-tap-ms = <175>;
-            require-prior-idle-ms = <175>;
+            tapping-term-ms = <150>;
+            quick-tap-ms = <125>;
+            require-prior-idle-ms = <100>;
             flavor = "hold-preferred";
             bindings = <&kp>, <&kp>;
         };


### PR DESCRIPTION
## Summary
- Reorganized layer access: space hold → SYMBOL layer, H hold → NUM layer, enter is standard key
- Added delete key mapping in SYMBOL layer (backspace → delete)
- Fixed F key homerow mod timing to prevent accidental 'f' when doing Shift+Enter
- Moved caps lock to dedicated key (bottom right), removed from escape hold

## Changes

### Layer Access Reorganization
- Space hold now accesses SYMBOL layer (was NUM layer)
- H hold now accesses NUM layer for ergonomic number entry on home row
- Enter is now a standard key without layer hold behavior

### SYMBOL Layer Enhancement
- Backspace now functions as Delete when in SYMBOL layer

### Homerow Mod Timing Fix
- F key now uses "hold-preferred" flavor instead of "balanced"
- Prevents accidental 'f' character when doing Shift+Enter (F+Enter)
- Other homerow mods remain unchanged with balanced flavor

### Caps Lock Refinement
- Removed caps lock toggle from escape key hold
- Bottom right key is now a dedicated caps lock key (was hyper macro)
- Escape is now a standard key without hold behavior

## Test Plan
- [ ] Verify space hold accesses SYMBOL layer
- [ ] Verify H hold accesses NUM layer  
- [ ] Verify enter works as standard key
- [ ] Verify backspace becomes delete in SYMBOL layer
- [ ] Test Shift+Enter (F+Enter) works reliably without printing 'f'
- [ ] Verify bottom right key toggles caps lock
- [ ] Verify escape works as standard key

🤖 Generated with [Claude Code](https://claude.com/claude-code)