### PR TITLE
Fix caps lock and hyper key positions

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -84,8 +84,8 @@
         default_layer {
             bindings = <
           &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O       &kp P   &kp BSPC
-  &kp ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &kp G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
-         &kp LCTRL       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &kp CAPS
+  &kp ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &lt_spc 1 G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
+         &kp CAPS       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &hyper
                                               &kp LGUI   &kp LSHFT  &lt_spc 2 SPACE    &kp RET   &kp RSHFT     &kp RALT
             >;
 


### PR DESCRIPTION
## Summary
- Corrected caps lock position to bottom left key
- Corrected hyper key position to bottom right key  
- Added holding G to activate number layer for symmetrical access with H

## Changes

### Key Position Corrections
- Bottom left key is now caps lock (was ctrl in previous PR)
- Bottom right key is now hyper (was incorrectly set to caps lock)

### Symmetrical Number Layer Access
- Both G and H now activate the number layer when held
- Provides balanced access to numbers from both home row keys

## Test Plan
- [ ] Verify bottom left key toggles caps lock
- [ ] Verify bottom right key activates hyper (Shift+Ctrl+Alt+Cmd)
- [ ] Verify holding G accesses number layer
- [ ] Verify holding H still accesses number layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)