### PR TITLE
fix: make space key act as space on NUM layer

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -97,7 +97,7 @@
 &kp ESC  &kp N1        &kp N2    &kp N3  &kp N4     &kp N5            &kp N6    &kp N7          &kp N8           &kp N9  &kp N0  &kp BACKSPACE
  &trans  &kp N4        &kp N5    &kp N6  &kp N0      &none          &kp LEFT  &kp DOWN          &kp UP        &kp RIGHT  &trans        &kp DEL
  &trans  &kp N7  &kp NUMBER_8    &kp N9  &kp N0      &none    &kp UNDERSCORE  &kp PLUS  &kp LEFT_BRACE  &kp RIGHT_BRACE  &trans         &trans
-                               &kp LGUI  &trans     &trans            &trans  &trans        &kp RALT
+                               &kp LGUI  &trans     &kp SPACE            &trans  &trans        &kp RALT
             >;
 
             display-name = "NUM";


### PR DESCRIPTION
## Summary
- Changed space key behavior on NUM layer from transparent to regular space key
- This allows space to function normally when holding G or H to access the NUM layer
- Previously, the transparent setting caused space to fall through to the base layer behavior (layer-tap to SYMBOL layer)

## Test plan
- [ ] Build firmware using GitHub Actions
- [ ] Flash firmware to keyboard
- [ ] Hold G or H to activate NUM layer
- [ ] Verify space bar types spaces instead of activating SYMBOL layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)