### PR TITLE
fix: adjust home row mod timings to reduce false positives

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -20,10 +20,10 @@
             compatible = "zmk,behavior-hold-tap";
             label = "HOMEROW_MODS";
             #binding-cells = <2>;
-            tapping-term-ms = <150>;
-            quick-tap-ms = <125>;
-            require-prior-idle-ms = <100>;
-            flavor = "balanced";
+            tapping-term-ms = <125>;
+            quick-tap-ms = <75>;
+            require-prior-idle-ms = <125>;
+            flavor = "tap-preferred";
             bindings = <&kp>, <&kp>;
         };
 


### PR DESCRIPTION
## Summary
- Adjusted home row mod behavior to tap-preferred with optimized timings
- Prevents modifier activation during normal typing while keeping responsive hold behavior

## Changes
- Changed flavor from `balanced` to `tap-preferred` - biases toward taps when timing is ambiguous
- Reduced `tapping-term-ms` from 150ms to 125ms - faster response for intentional holds
- Reduced `quick-tap-ms` from 125ms to 75ms - tighter double-tap window
- Increased `require-prior-idle-ms` from 100ms to 125ms - requires more deliberate pause before holds

## Test plan
- [ ] Build and flash firmware
- [ ] Test normal typing doesn't trigger modifiers
- [ ] Test intentional holds (Ctrl, Alt, Gui, Shift) still work
- [ ] Verify quick double-taps work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)