### PR TITLE
fix: relax home row mod timing and make enter tap-only

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -20,11 +20,20 @@
             compatible = "zmk,behavior-hold-tap";
             label = "HOMEROW_MODS";
             #binding-cells = <2>;
-            tapping-term-ms = <125>;
-            quick-tap-ms = <75>;
-            require-prior-idle-ms = <125>;
+            tapping-term-ms = <175>;
+            quick-tap-ms = <150>;
+            require-prior-idle-ms = <175>;
             flavor = "tap-preferred";
             bindings = <&kp>, <&kp>;
+        };
+
+        tap_only: tap_only {
+            compatible = "zmk,behavior-hold-tap";
+            label = "TAP_ONLY";
+            #binding-cells = <2>;
+            tapping-term-ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&none>, <&kp>;
         };
 
         lt_spc: layer_tap_space {
@@ -86,7 +95,7 @@
           &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O       &kp P   &kp BSPC
   &kp ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &lt_spc 1 G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
          &kp CAPS       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &hyper
-                                              &kp LGUI   &kp LSHFT  &lt_spc 2 SPACE    &kp RET   &kp RSHFT     &kp RALT
+                                              &kp LGUI   &kp LSHFT  &lt_spc 2 SPACE    &tap_only 0 RET   &kp RSHFT     &kp RALT
             >;
 
             display-name = "ALPHA";


### PR DESCRIPTION
## Summary
- Relaxed home row mod timing to reduce false modifier activations when typing fast
- Added `tap_only` behavior and applied it to enter key (hold now does nothing)

## Changes
| Setting | Before | After |
|---------|--------|-------|
| `tapping-term-ms` | 125 | 175 |
| `quick-tap-ms` | 75 | 150 |
| `require-prior-idle-ms` | 125 | 175 |

## Test plan
- [ ] Flash firmware to both halves
- [ ] Type quickly and verify no accidental modifier activations
- [ ] Hold enter key and verify it does nothing
- [ ] Tap enter key and verify it works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)