### PR TITLE
fix: revert enter key to normal behavior

### DIFF
--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -27,15 +27,6 @@
             bindings = <&kp>, <&kp>;
         };
 
-        tap_only: tap_only {
-            compatible = "zmk,behavior-hold-tap";
-            label = "TAP_ONLY";
-            #binding-cells = <2>;
-            tapping-term-ms = <0>;
-            flavor = "tap-preferred";
-            bindings = <&none>, <&kp>;
-        };
-
         lt_spc: layer_tap_space {
             compatible = "zmk,behavior-hold-tap";
             label = "LAYER_TAP_SPACE";
@@ -95,7 +86,7 @@
           &kp TAB       &kp Q       &kp W       &kp E        &kp R      &kp T      &kp Y        &kp U        &kp I       &kp O       &kp P   &kp BSPC
   &kp ESCAPE  &hm LCTRL A  &hm LALT S  &hm LGUI D  &hm LSHFT F      &lt_spc 1 G      &lt_spc 1 H  &hm RSHFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI    &kp SQT
          &kp CAPS       &kp Z       &kp X       &kp C        &kp V      &kp B      &kp N        &kp M    &kp COMMA     &kp DOT    &kp FSLH     &hyper
-                                              &kp LGUI   &kp LSHFT  &lt_spc 2 SPACE    &tap_only 0 RET   &kp RSHFT     &kp RALT
+                                              &kp LGUI   &kp LSHFT  &lt_spc 2 SPACE    &kp RET   &kp RSHFT     &kp RALT
             >;
 
             display-name = "ALPHA";


### PR DESCRIPTION
## Summary
- Reverts enter key from `tap_only` behavior back to normal `&kp RET`
- The `tap_only` behavior was too aggressive and prevented enter from working at all

## Test plan
- [ ] Flash firmware and verify enter key works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)