### PR TITLE
fix: disable ; and ' keys on NUM layer to prevent mistypes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,10 @@
       "Bash(git push:*)",
       "Bash(gh pr create:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git fetch:*)",
+      "Bash(git rebase:*)",
+      "Bash(git stash:*)"
     ],
     "deny": [],
     "ask": []

--- a/config/corne_v3.keymap
+++ b/config/corne_v3.keymap
@@ -95,7 +95,7 @@
         layer_lower {
             bindings = <
 &kp ESC  &kp N1        &kp N2    &kp N3  &kp N4     &kp N5            &kp N6    &kp N7          &kp N8           &kp N9  &kp N0  &kp BACKSPACE
- &trans  &kp N4        &kp N5    &kp N6  &kp N0      &none          &kp LEFT  &kp DOWN          &kp UP        &kp RIGHT  &trans        &kp DEL
+ &trans  &kp N4        &kp N5    &kp N6  &kp N0      &none          &kp LEFT  &kp DOWN          &kp UP        &kp RIGHT  &none         &none
  &trans  &kp N7  &kp NUMBER_8    &kp N9  &kp N0      &none    &kp UNDERSCORE  &kp PLUS  &kp LEFT_BRACE  &kp RIGHT_BRACE  &trans         &trans
                                &kp LGUI  &trans     &kp SPACE            &trans  &trans        &kp RALT
             >;


### PR DESCRIPTION
## Summary
- Disable `;` and `'` keys on the NUM layer (activated by holding G or H)
- Prevents accidental keypresses from passing through when using the number layer

## Test plan
- [ ] Flash firmware to keyboard
- [ ] Hold G or H to activate NUM layer
- [ ] Verify pressing `;` or `'` does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)