### PR TITLE
build: add settings_reset firmware target

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -22,3 +22,5 @@ include:
     snippet: studio-rpc-usb-uart
   - board: nice_nano_v2
     shield: corne_right nice_view_adapter nice_view
+  - board: nice_nano_v2
+    shield: settings_reset


### PR DESCRIPTION
## Summary
- Adds a `settings_reset` shield build to `build.yaml` for the nice_nano_v2 board, producing a reset firmware artifact alongside the existing Corne V3 and BOMv2 Corne builds.

The reset firmware is flashed to a half when its split-pairing/settings need to be cleared (e.g. when re-pairing halves or recovering from a bad state).

## Test plan
- [ ] CI build succeeds and a `settings_reset` artifact is produced in the Actions run
- [ ] Flash `settings_reset.uf2` to a half, then re-flash the normal firmware and confirm the halves re-pair